### PR TITLE
Update NodesControl.cs - ExportToXml bug fix

### DIFF
--- a/NodeEditor/NodesControl.cs
+++ b/NodeEditor/NodesControl.cs
@@ -797,7 +797,7 @@ namespace NodeEditor
             var connections = el.AppendChild(xml.CreateElement("Connections"));
             foreach (var conn in graph.Connections)
             {
-                var xmlConn = (XmlElement)nodes.AppendChild(xml.CreateElement("Connection"));
+                var xmlConn = (XmlElement)connections.AppendChild(xml.CreateElement("Connection"));
                 xmlConn.SetAttribute("OutputNodeId", conn.OutputNode.GetGuid());
                 xmlConn.SetAttribute("OutputNodeSocket", conn.OutputSocketName);
                 xmlConn.SetAttribute("InputNodeId", conn.InputNode.GetGuid());


### PR DESCRIPTION
var xmlConn = (XmlElement)nodes.AppendChild(xml.CreateElement("Connection")); 
update to 
var xmlConn = (XmlElement)connections.AppendChild(xml.CreateElement("Connection"));

At the moment the xml in output is not formatted in the right way.